### PR TITLE
Example: sentry + fixes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,17 +5,23 @@ import (
 )
 
 // ErrDuplicateState is thrown when there are indexes of the same value
-type ErrDuplicateState Index
+type ErrDuplicateState struct {
+	*spec
+	Index
+}
 
 func (e ErrDuplicateState) Error() string {
-	return fmt.Sprintf("duplicated state index: %v", e)
+	return fmt.Sprintf("duplicated state index: %v", e.spec.stateName(e.Index))
 }
 
 // ErrUnknownState indicates the state referenced does not match a known state index
-type ErrUnknownState Index
+type ErrUnknownState struct {
+	*spec
+	Index
+}
 
 func (e ErrUnknownState) Error() string {
-	return fmt.Sprintf("unknown state: %v", e)
+	return fmt.Sprintf("unknown state: %v", e.spec.stateName(e.Index))
 }
 
 // ErrUnknownTransition indicates an unknown signal while in given state is raised
@@ -32,14 +38,14 @@ func (e ErrUnknownTransition) Error() string {
 
 // ErrUnknownSignal is raised when a undefined signal is received in the given state
 type ErrUnknownSignal struct {
-	spec   *spec
-	Signal Signal
-	State  Index
-	Help   string
+	spec *spec
+	Signal
+	Index
+	Help string
 }
 
 func (e ErrUnknownSignal) Error() string {
-	return fmt.Sprintf("unknown signal: signal=%v, state=%v", e.spec.signalName(e.Signal), e.spec.stateName(e.State))
+	return fmt.Sprintf("unknown signal: signal=%v, state=%v", e.spec.signalName(e.Signal), e.spec.stateName(e.Index))
 }
 
 // ErrUnknownFSM is raised when the ID is does not match any thing in the set

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,64 @@
+# Set an output prefix, which is the local directory if not specified
+PREFIX?=$(shell pwd -L)
+
+# Used to populate version variable in main package.
+VERSION?=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
+REVISION?=$(shell git rev-list -1 HEAD)
+
+# Allow turning off function inlining and variable registerization
+ifeq (${DISABLE_OPTIMIZATION},true)
+	GO_GCFLAGS=-gcflags "-N -l"
+	VERSION:="$(VERSION)-noopt"
+endif
+
+.PHONY: clean vet lint
+.DEFAULT: sentry
+all: clean vet lint sentry
+
+AUTHORS: .mailmap .git/HEAD
+	git log --format='%aN <%aE>' | sort -fu > $@
+
+vet:
+	@echo "+ $@"
+	@go vet $(PKGS)
+
+lint:
+	@echo "+ $@"
+	$(if $(shell which golint || echo ''), , \
+		$(error Please install golint: `make get-tools`))
+	@test -z "$$(golint ./... 2>&1 | grep -v ^vendor/ | grep -v mock/ | tee /dev/stderr)"
+
+clean:
+	@echo "+ $@"
+	rm -rf build
+	mkdir -p build
+
+define binary_target_template
+$(1): $(1).go lint vet
+	$(eval HASH := $(shell git hash-object $(1).go))  # hash of source code
+	@echo "$@"
+	@mkdir -p build
+ifneq (,$(findstring .m,$(VERSION)))
+		@echo "\nWARNING - repository contains uncommitted changes, tagged binaries as dirty\n"
+endif
+	@echo "\nBuilding $(1).go with hash=$(HASH)"
+	go build -o build/$(1) \
+		-tags "$(GO_BUILD_TAGS)" \
+		-ldflags "\
+		-X main.VERSION=$(VERSION) \
+		-X main.REVISION=$(REVISION) \
+		-X main.HASH=$(HASH)\
+		" \
+		$(1).go
+endef
+
+define define_binary_target
+	$(eval $(call binary_target_template,$(1)))
+endef
+
+# All the possible targets
+
+# Sentry is the example that shows how to use the fsm in a server that
+# is able to watch over a set of other http servers and start them
+# if necessary.
+$(call define_binary_target,sentry)

--- a/examples/cluster_agents_test.go
+++ b/examples/cluster_agents_test.go
@@ -74,7 +74,7 @@ func TestClusterCases(t *testing.T) {
 	machines, err := Define(
 		State{
 			Index: start,
-			TTL:   Expiry{noData, timeout},
+			TTL:   Expiry{TTL: noData, Raise: timeout},
 			Transitions: map[Signal]Index{
 				agentReady: matchedAgent,
 				agentDown:  matchedAgent,
@@ -84,7 +84,7 @@ func TestClusterCases(t *testing.T) {
 		},
 		State{
 			Index: matchedInstance,
-			TTL:   Expiry{agentJoin, agentGone},
+			TTL:   Expiry{TTL: agentJoin, Raise: agentGone},
 			Transitions: map[Signal]Index{
 				agentReady:   clusterNode,
 				agentDown:    clusterNode,
@@ -97,7 +97,7 @@ func TestClusterCases(t *testing.T) {
 		},
 		State{
 			Index: pendingInstanceDestroy,
-			TTL:   Expiry{waitBeforeInstanceDestroy, reap},
+			TTL:   Expiry{TTL: waitBeforeInstanceDestroy, Raise: reap},
 			Transitions: map[Signal]Index{
 				agentReady:   clusterNode, // late joiner
 				agentDown:    clusterNode,
@@ -111,7 +111,7 @@ func TestClusterCases(t *testing.T) {
 		},
 		State{
 			Index: matchedAgent,
-			TTL:   Expiry{waitDescribeInstances, instanceGone},
+			TTL:   Expiry{TTL: waitDescribeInstances, Raise: instanceGone},
 			Transitions: map[Signal]Index{
 				instanceOK:   clusterNode,
 				instanceGone: removedInstance,
@@ -140,7 +140,7 @@ func TestClusterCases(t *testing.T) {
 		},
 		State{
 			Index: clusterNodeDown,
-			TTL:   Expiry{waitBeforeReprovision, agentGone},
+			TTL:   Expiry{TTL: waitBeforeReprovision, Raise: agentGone},
 			Transitions: map[Signal]Index{
 				agentReady:   clusterNodeReady,
 				agentGone:    pendingInstanceDestroy,
@@ -149,7 +149,7 @@ func TestClusterCases(t *testing.T) {
 		},
 		State{
 			Index: removedInstance, // after we removed the instance, we can still have unmatched node
-			TTL:   Expiry{waitBeforeCleanup, timeout},
+			TTL:   Expiry{TTL: waitBeforeCleanup, Raise: timeout},
 			Transitions: map[Signal]Index{
 				agentDown: done,
 				timeout:   done,

--- a/examples/cluster_provision_test.go
+++ b/examples/cluster_provision_test.go
@@ -43,7 +43,7 @@ func simpleProvisionModel(actions map[Signal]Action) Machines {
 			Actions: map[Signal]Action{
 				create: actions[create],
 			},
-			TTL: Expiry{3, create},
+			TTL: Expiry{TTL: 3, Raise: create},
 		},
 		State{
 			Index: creating,
@@ -84,7 +84,7 @@ func simpleProvisionModel(actions map[Signal]Action) Machines {
 				cordon:    actions[cordon],
 				terminate: actions[terminate],
 			},
-			TTL: Expiry{5, cordon},
+			TTL: Expiry{TTL: 5, Raise: cordon},
 		},
 		State{
 			Index: cordoned,
@@ -147,7 +147,7 @@ func (c *cluster) countByState(state Index) int {
 	for i := range c.nodes {
 		for j := range c.nodes[i] {
 			if c.nodes[i][j].State() == state {
-				total += 1
+				total++
 			}
 		}
 	}

--- a/examples/sentry.conf
+++ b/examples/sentry.conf
@@ -1,0 +1,11 @@
+{
+    "http://localhost:9091" : "build/sentry - :9091"
+    ,
+    "http://localhost:9092" : "build/sentry - :9092"
+    ,
+    "http://localhost:9093" : "build/sentry - :9093"
+    ,
+    "http://localhost:9094" : "build/sentry - :9094"
+    ,
+    "http://localhost:9095" : "build/sentry - :9095"
+}

--- a/examples/sentry.go
+++ b/examples/sentry.go
@@ -1,0 +1,429 @@
+package main
+
+import (
+	"github.com/orkestr8/fsm"
+
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	// VERSION is the git version.
+	VERSION string
+	// REVISION is the git rev.
+	REVISION string
+	// HASH is a hash value that's computed based on some file at build time.
+	HASH string
+)
+
+const (
+	envSentryStartDelay   = "SENTRY_START_DELAY"
+	envSentryPollInterval = "SENTRY_POLL_INTERVAL"
+)
+
+func main() {
+
+	if len(os.Args) != 3 {
+		log.Fatal("Must have two args:" + os.Args[0] + " config_file listen_port")
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config := map[string]string{}
+
+	if os.Args[1] != "-" {
+		// Filepath as given
+		bytes, err := ioutil.ReadFile(os.Args[1])
+
+		if err != nil {
+
+			// relative to current working directory
+			parent := filepath.Dir(os.Args[0])
+			bytes, err = ioutil.ReadFile(filepath.Join(parent, os.Args[1]))
+
+			if err != nil {
+
+				// try working directory
+				bytes, err = ioutil.ReadFile(filepath.Join(pwd, os.Args[1]))
+
+				if err != nil {
+					log.Fatal(err)
+				}
+
+			}
+		}
+
+		if err := json.Unmarshal(bytes, &config); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	sentry := &sentry{
+		targets: map[fsm.ID]string{},
+		fsms:    map[string]fsm.FSM{},
+		pwd:     pwd,
+		listen:  os.Args[2],
+		config:  config,
+		stopC:   make(chan interface{}),
+	}
+
+	if delay := os.Getenv(envSentryStartDelay); delay == "" {
+		sentry.delay = 3 * time.Second
+	} else if sentry.delay, err = time.ParseDuration(delay); err != nil {
+		log.Fatal(err)
+	}
+
+	if tick := os.Getenv(envSentryPollInterval); tick == "" {
+		sentry.tickC = time.Tick(1 * time.Second)
+	} else if t, err := time.ParseDuration(tick); err != nil {
+		log.Fatal(err)
+	} else {
+		sentry.tickC = time.Tick(t)
+	}
+
+	if err := sentry.initialize(); err != nil {
+		log.Fatal(err)
+	}
+
+	sentry.handleHTTP()
+
+	log.Print("Starting up server with config of ", len(sentry.config), " targets.")
+	log.Print("Server has start up delay of ", sentry.delay)
+
+	time.Sleep(sentry.delay)
+
+	go sentry.poll()
+
+	log.Print("Listening on: ", sentry.listen)
+	log.Fatal(http.ListenAndServe(sentry.listen, nil))
+}
+
+type serverError struct {
+	*http.Response
+}
+
+func (e *serverError) Error() string {
+	return fmt.Sprintf("HTTP_STATUS[%v]", e.Response.StatusCode)
+}
+
+type sentry struct {
+	machines    fsm.Machines
+	fsms        map[string]fsm.FSM
+	targets     map[fsm.ID]string
+	pwd         string
+	listen      string
+	config      map[string]string
+	delay       time.Duration
+	maintenance bool
+
+	lock sync.RWMutex
+
+	tickC <-chan time.Time
+	stopC chan interface{}
+}
+
+const (
+	targetUnknown fsm.Index = iota
+	targetRunning
+	targetError
+	targetDown
+	targetProvisioning
+	targetStopping
+
+	foundRunning fsm.Signal = iota
+	foundError
+	foundDown
+	doKill
+	doProvision
+)
+
+func (a *sentry) initialize() (err error) {
+	a.machines, err = fsm.Define(
+		fsm.State{
+			Index: targetUnknown,
+			Transitions: map[fsm.Signal]fsm.Index{
+				foundRunning: targetRunning,
+				foundError:   targetError,
+				foundDown:    targetDown,
+			},
+		},
+		fsm.State{
+			Index: targetRunning,
+			Transitions: map[fsm.Signal]fsm.Index{
+				foundError: targetError,
+				foundDown:  targetDown,
+			},
+		},
+		fsm.State{
+			Index: targetError,
+			Transitions: map[fsm.Signal]fsm.Index{
+				foundRunning: targetRunning,
+				foundDown:    targetDown,
+				doKill:       targetStopping,
+			},
+			TTL: fsm.Expiry{TTL: 5, Raise: doKill},
+			Actions: map[fsm.Signal]fsm.Action{
+				doKill: func(f fsm.FSM) error {
+
+					target, has := a.targets[f.ID()]
+					if !has {
+						log.Fatal("Missing target for ID ", f.ID())
+					}
+
+					url := target + "/kill"
+					log.Println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> kill: ", url)
+
+					_, err := http.Get(url)
+					return err
+				},
+			},
+		},
+		fsm.State{
+			Index: targetDown,
+			Transitions: map[fsm.Signal]fsm.Index{
+				foundRunning: targetRunning,
+				foundError:   targetError,
+				doProvision:  targetRunning,
+			},
+			TTL: fsm.Expiry{TTL: 5, Raise: doProvision},
+			Actions: map[fsm.Signal]fsm.Action{
+				doProvision: func(f fsm.FSM) error {
+
+					target, has := a.targets[f.ID()]
+					if !has {
+						log.Fatal("Missing target for ID ", f.ID())
+					}
+					log.Println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> provision: ", target)
+
+					return a.provision(target)
+				},
+			},
+		},
+		fsm.State{
+			Index: targetProvisioning,
+			Transitions: map[fsm.Signal]fsm.Index{
+				foundRunning: targetRunning,
+				foundError:   targetError,
+			},
+		},
+		fsm.State{
+			Index: targetStopping,
+			Transitions: map[fsm.Signal]fsm.Index{
+				foundError: targetError,
+				foundDown:  targetDown,
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	options := fsm.DefaultOptions()
+	options.StateNames = map[fsm.Index]string{
+		targetUnknown:      "UNKNOWN",
+		targetRunning:      "RUNNING",
+		targetError:        "ERROR",
+		targetDown:         "DOWN",
+		targetProvisioning: "PROVISIONING",
+		targetStopping:     "STOPPING",
+	}
+	options.SignalNames = map[fsm.Signal]string{
+		foundRunning: "running",
+		foundError:   "error",
+		foundDown:    "down",
+	}
+
+	a.machines.Run(fsm.Wall(time.Tick(2*time.Second)), options)
+
+	// for each target create an instance
+	for target := range a.config {
+
+		f, err := a.machines.New(targetUnknown)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		a.fsms[target] = f
+		a.targets[f.ID()] = target
+	}
+
+	return nil
+}
+
+func (a *sentry) states() (states map[string]interface{}) {
+	states = map[string]interface{}{}
+
+	for target := range a.fsms {
+		states[target] = a.machines.StateStringer(a.fsms[target].State())
+	}
+	return
+}
+
+func (a *sentry) handleHTTP() {
+
+	http.HandleFunc("/",
+		func(w http.ResponseWriter, r *http.Request) {
+			log.Println(a.listen, "- PING", r.RemoteAddr)
+			a.lock.RLock()
+			defer a.lock.RUnlock()
+
+			if a.maintenance {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(fmt.Sprintf("%s,%s,%s", VERSION, REVISION, HASH)))
+		},
+	)
+	http.HandleFunc("/kill",
+		func(w http.ResponseWriter, r *http.Request) {
+			log.Println("kill", r.RemoteAddr)
+			close(a.stopC)
+		},
+	)
+	http.HandleFunc("/maintenance",
+		func(w http.ResponseWriter, r *http.Request) {
+			log.Println("maintenance", r.RemoteAddr)
+			a.lock.Lock()
+			defer a.lock.Unlock()
+			a.maintenance = !a.maintenance
+		},
+	)
+	http.HandleFunc("/provision",
+		func(w http.ResponseWriter, r *http.Request) {
+			target := r.URL.Query().Get("target")
+			if target == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			go a.provision(target)
+		},
+	)
+	http.HandleFunc("/state",
+		func(w http.ResponseWriter, r *http.Request) {
+			log.Println("state", r.RemoteAddr)
+
+			keys := []string{}
+			all := a.states()
+			for k := range all {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Fprintf(w, "%s\t%s\n", k, all[k])
+			}
+		},
+	)
+}
+
+func (a *sentry) poll() {
+
+	targets := []string{}
+	for k := range a.config {
+		targets = append(targets, k)
+	}
+	sort.Strings(targets)
+	log.Println("Polling for ", len(targets), " targets")
+
+loop:
+	for i := 0; ; i++ {
+
+		select {
+		case <-a.tickC:
+
+			if len(a.config) == 0 {
+				continue loop
+			}
+
+			target := targets[i%len(targets)]
+
+			log.Println(target, "- Polling")
+
+			resp, err := http.Get(target)
+			if err == nil {
+
+				switch resp.StatusCode {
+
+				case http.StatusOK:
+					log.Println(target, "- OK")
+					a.signal(target, foundRunning)
+					continue loop
+
+				default:
+					err = &serverError{resp}
+				}
+			}
+
+			switch err := err.(type) {
+			case *serverError:
+				log.Println(target, "- SERVER_ERROR, err=", err)
+				a.signal(target, foundError)
+
+			case net.Error:
+				log.Println(target, "- NETWORK_ERROR, timeout=", err.Timeout(), ", temporary=", err.Temporary())
+				a.signal(target, foundDown)
+
+			default:
+				log.Println(target, "- UNKNOWN_ERROR, err=", err)
+				a.signal(target, foundError)
+			}
+		case <-a.stopC:
+			break loop
+		}
+	}
+
+	log.Println("Stopped")
+	os.Exit(0)
+
+}
+
+func (a *sentry) signal(target string, signal fsm.Signal) error {
+	fsm, has := a.fsms[target]
+	if !has {
+		log.Println(target, "- NOT FOUND")
+		return nil
+	}
+	return fsm.Signal(signal)
+}
+
+func (a *sentry) provision(target string) error {
+	cmd, has := a.config[target]
+	if !has {
+		return fmt.Errorf("Target not found %v", target)
+	}
+
+	p := strings.Split(cmd, " ")
+
+	if p[0] == "build/sentry" {
+		// !!!! This works only if you run from the examples directory !!!
+		p[0] = filepath.Join(a.pwd, p[0]) // make sure the path exists
+	}
+
+	x := exec.Command(p[0], p[1:]...)
+	x.Dir = a.pwd
+
+	log.Println(target, "- PROVISION, cmd=", cmd, "with", x.Path, x.Args)
+
+	if err := x.Start(); err != nil {
+		out, _ := x.CombinedOutput()
+		log.Println(target, "- ERROR_PROVISION, err=", err, "out=", string(out))
+		return err
+	}
+
+	return nil
+}

--- a/flap.go
+++ b/flap.go
@@ -38,7 +38,7 @@ func (s *spec) compileFlapping(checks []Flap) (*spec, error) {
 		// check the state
 		for _, state := range check.States {
 			if _, has := s.states[state]; !has {
-				return nil, ErrUnknownState(state)
+				return nil, ErrUnknownState{spec: s, Index: state}
 			}
 		}
 

--- a/machines.go
+++ b/machines.go
@@ -1,5 +1,9 @@
 package fsm // import "github.com/orkestr8/fsm"
 
+import (
+	"fmt"
+)
+
 type machines struct {
 	*spec
 	Options
@@ -36,4 +40,18 @@ func (m *machines) Done() {
 	}
 
 	m.runner.Stop()
+}
+
+type stringer string
+
+func (s stringer) GoString() string {
+	return string(s)
+}
+
+func (m *machines) StateStringer(i Index) fmt.GoStringer {
+	return stringer(m.spec.stateName(i))
+}
+
+func (m *machines) SignalStringer(s Signal) fmt.GoStringer {
+	return stringer(m.spec.signalName(s))
 }

--- a/runner.go
+++ b/runner.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	defaultBufferSize = 100
+	defaultBufferSize = 1 << 8
 )
 
 // runner manages the channels used to receive state transition signals
@@ -101,8 +101,7 @@ func (g *runner) handleError(tid int64, err error, ctx interface{}) {
 		if g.options.IgnoreUndefinedStates {
 			return
 		}
-		message = fmt.Sprintf("%s: %v", err.Error(),
-			g.spec.stateName(Index(err)))
+		message = fmt.Sprintf("Unknown: %v", err)
 
 	case ErrUnknownTransition:
 		if g.options.IgnoreUndefinedTransitions {
@@ -115,12 +114,11 @@ func (g *runner) handleError(tid int64, err error, ctx interface{}) {
 		if g.options.IgnoreUndefinedSignals {
 			return
 		}
-		message = fmt.Sprintf("%s: state(%v) on signal(%v)", err.Error(),
-			g.spec.stateName(Index(err.State)), g.spec.signalName(Signal(err.Signal)))
+		message = fmt.Sprintf("UnknownSignal: %v, state(%v) on signal(%v)", err,
+			g.spec.stateName(Index(err.Index)), g.spec.signalName(Signal(err.Signal)))
 
 	case ErrDuplicateState:
-		message = fmt.Sprintf("%s: %v", err.Error(),
-			g.spec.stateName(Index(err)))
+		message = fmt.Sprintf("Duplicate: %v", err)
 
 	case ErrUnknownFSM:
 		message = fmt.Sprintf("%s: %v", err.Error(), err)

--- a/types.go
+++ b/types.go
@@ -1,5 +1,9 @@
 package fsm // import "github.com/orkestr8/fsm"
 
+import (
+	"fmt"
+)
+
 // ID is the id of the instance in a given set.  It's unique in that set.
 type ID uint64
 
@@ -127,20 +131,11 @@ type Logger interface {
 
 // Backgrounder runs in the background
 type Backgrounder interface {
-	// Run starts the backgrounder
-	//	Run() error
 	// Stop stops the state machine loop
 	Stop()
 }
 
-// Runner is the interface for managing instances
-type Runner interface {
-	Backgrounder
-
-	// Alloc allocates an instance of FSM for tracking of state
-	//	Alloc(Index) (FSM, error)
-}
-
+// Machines is the main interface to allocate new instances and to start tracking the states.
 type Machines interface {
 
 	// New allocates an instance of FSM for tracking of state
@@ -151,4 +146,10 @@ type Machines interface {
 
 	// Done stops everything and releases all resources
 	Done()
+
+	// StateStringer returns the state in printable form
+	StateStringer(Index) fmt.GoStringer
+
+	// SignalStringer returns the signal in printable form
+	SignalStringer(Signal) fmt.GoStringer
 }


### PR DESCRIPTION
  + API fixes
  + errors implementation
  + example - `sentry`, which is a simple server that monitors other servers using a simple http protocol for checking statuses; it runs locally on a single host.  It's a trivial example to show the use of the state machines for tracking.