### PR TITLE
Fix race

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -57,7 +57,7 @@ endef
 
 # All the possible targets
 
-# Sentry is the example that shows how to use the fsm in a server that
+# Simple is the example that shows how to use the fsm in a server that
 # is able to watch over a set of other http servers and start them
 # if necessary.
 $(call define_binary_target,simple)


### PR DESCRIPTION
Fix data races with clock's `Start` and `Stop` methods.

To test

```
GOMAXPROCS=4 go test -v -race -count=1 .
```

Signed-off-by: David C <davidc616+github_chungers@gmail.com>